### PR TITLE
Removed image and added commenter_id for comment

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -431,7 +431,7 @@ exports.VerifyEmail = async (req, res) =>
 exports.AddComment = async (req, res) =>
 {
   const { userid } = req;
-  const { project_id, fname, userimg, data } = req.body;
+  const { project_id, fname, data } = req.body;
   const createdat = moment().format("MMMM Do YYYY, h:mm:ss a");
   try
   {
@@ -441,7 +441,7 @@ exports.AddComment = async (req, res) =>
         $push: {
           comments: {
             fname: fname,
-            userimg: userimg,
+            commenter_id: userid,
             data: data,
             createdat: createdat,
           },

--- a/server/db/schema/projectSchema.js
+++ b/server/db/schema/projectSchema.js
@@ -38,7 +38,7 @@ const projectSchema = mongoose.Schema({
       fname: {
         type: String,
       },
-      userimg: {
+      commenter_id: {
         type: String,
       },
       data: {

--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -25,10 +25,10 @@
 }
 
 .email_verified_msg{
-  margin-top: "1rem";
-  display: "flex";
-  justify-content: "center";
-  align-items: "center";
+  margin-top: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .btn {

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -333,7 +333,7 @@ const Profile = () =>
             </RouterLink>
             {isemailverified ? (
               <div className="email_verified_msg">
-                <strong>Email Verified</strong> <CheckCircleIcon />
+                <strong>Email Verified  </strong> <CheckCircleIcon/>
               </div>
             ) : (
               <button className="editbtn" onClick={emailVerifyBtn}>

--- a/src/components/ProjectDetails/ProjectDetails.js
+++ b/src/components/ProjectDetails/ProjectDetails.js
@@ -79,7 +79,6 @@ function ProjectDetails(props)
     const data = {
       project_id: ProjectDetails.id,
       fname: user.fname,
-      userimg: dashboard.profile_pic,
       data: comment,
     };
 
@@ -178,11 +177,6 @@ function ProjectDetails(props)
         <div className="comment_user_data">
           <h1> Add Your Suggestion </h1>
           <div className="comment_user">
-            <img
-              src={dashboard.profile_pic ? dashboard.profile_pic : userImg}
-              alt="user_image"
-            />
-
             <h2>{user.fname ? user.fname : "Guest"}</h2>
           </div>
 
@@ -207,13 +201,9 @@ function ProjectDetails(props)
             <div className="user_comment" key={comment._id}>
               <div className="comment_info">
                 <div className="comment_user">
-                  <img
-                    src={
-                      dashboard.profile_pic ? dashboard.profile_pic : userImg
-                    }
-                    alt="user_image"
-                  />
-                  <h2>{comment.fname}</h2>
+                  <RouterLink to={`/profile/${comment.commenter_id}`}>
+                    <h2>{comment.fname}</h2>
+                  </RouterLink>
                 </div>
                 <p className="comment_timestamp">{comment.createdat}</p>
               </div>


### PR DESCRIPTION
### Description

- commenter's image is not being added now for comment 
- commenter_id is being added now for comment, which is being used to show commenter's profile onclick to commenter's name

Fixes #244

### Type of Change:
- Bugs


### How Has This Been Tested?
Its not saving image now for comment and showing commenter's profile onclick to name correctly . 
It is checked on predicting music genres project.


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes