### PR TITLE
Added added_by for project details

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -170,7 +170,7 @@ exports.ResetPassword = async (req, res) =>
 exports.AddNewProject = async (req, res) =>
 {
   const { userid } = req;
-  const { name, description, level, skills, github } = req.body;
+  const { name, description, level, skills, github, adder_id, adder_fname } = req.body;
 
   let username = "";
 
@@ -182,6 +182,8 @@ exports.AddNewProject = async (req, res) =>
       level,
       skills,
       github,
+      adder_id,
+      adder_fname
     });
 
     const projectres = await newProject.save();

--- a/server/db/schema/projectSchema.js
+++ b/server/db/schema/projectSchema.js
@@ -19,6 +19,14 @@ const projectSchema = mongoose.Schema({
       required: true,
     },
   ],
+  adder_id: {
+    type : String,
+    default: ''
+  },
+  adder_fname: {
+    type : String,
+    default: 'Project Zone',
+  },
   likes: {
     type: Number,
     default: 0,

--- a/src/components/AddNewProject/AddNewProject.js
+++ b/src/components/AddNewProject/AddNewProject.js
@@ -73,7 +73,7 @@ const useStyles = makeStyles((theme) => ({
 function AddNewProject() {
   const classes = useStyles();
   const history = useHistory();
-  const [{ ProjectDetails, dashboard, isAuthenticated }, dispatch] =
+  const [{ ProjectDetails, user, dashboard, isAuthenticated }, dispatch] =
     useDataLayerValues();
   useEffect(() => {
     !isAuthenticated && history.replace("/login");
@@ -139,6 +139,8 @@ function AddNewProject() {
       skills: skillInputs,
       description: desc,
       github: github,
+      adder_id: user.userid,
+      adder_fname: user.fname
     };
 
     try {

--- a/src/components/ProjectDetailCard/ProjectDetailCard.css
+++ b/src/components/ProjectDetailCard/ProjectDetailCard.css
@@ -104,4 +104,21 @@
   flex-wrap:wrap;
 }
 
+.adder_div{
+  margin-top:0.8rem;
+  margin-right:auto;
+  display: flex;
+  flex-wrap : wrap;
+}
+
+.adder_div h2{
+  font-size:18px;
+  color: #6f6ee1;
+  margin:0;
+  margin-left:-5px;
+  margin-right:5px;
+  font-weight: bold;
+  font-family: "Poppins";
+}
+
 

--- a/src/components/ProjectDetailCard/ProjectDetailCard.js
+++ b/src/components/ProjectDetailCard/ProjectDetailCard.js
@@ -8,6 +8,7 @@ import { AddLike, AddNewRating, AddBadge } from "./../../axios/instance";
 import { toast } from "react-toastify";
 import FavoriteIcon from "@material-ui/icons/Favorite";
 import Rating from "@material-ui/lab/Rating";
+import { Link as RouterLink } from "react-router-dom";
 import { GitHub } from "@material-ui/icons";
 import { getSkillColor } from "../../utils";
 
@@ -245,6 +246,20 @@ function ProjectDetailCard()
               </div>
             ))}
         </div>
+        <div className="adder_div">
+          <h4 className="like_label_">Added By </h4>
+          {ProjectDetails.adder_id ? 
+           <RouterLink to={`/profile/${ProjectDetails.adder_id}`}>
+              <h2>{ProjectDetails.adder_fname}</h2>
+           </RouterLink>
+           : <h2>{ProjectDetails.adder_fname}</h2>
+          }
+          {ProjectDetails.github ? (
+            <a style={{ color: "black" }} target="_blank" href={ProjectDetails.github}>
+              <GitHub />
+            </a>
+          ) : null}
+        </div>
         <div className="rating_div">
           <h4 className="like_label_">
             {!liked ? "Give it a Like" : "You have liked this project"}
@@ -270,11 +285,6 @@ function ProjectDetailCard()
             readOnly={rated}
             onChange={newRatingHandler}
           />
-          {ProjectDetails.github ? (
-            <a style={{ color: "black" }} href={ProjectDetails.github}>
-              <GitHub />
-            </a>
-          ) : null}
         </div>
        </div>
       </div>

--- a/src/components/ProjectDetails/ProjectDetails.js
+++ b/src/components/ProjectDetails/ProjectDetails.js
@@ -51,6 +51,8 @@ function ProjectDetails(props)
           likes: project.data.likes,
           comments: project.data.comments,
           github: project.data.github,
+          adder_id: project.data.adder_id, 
+          adder_fname: project.data.adder_fname
         },
       });
     } 
@@ -197,7 +199,7 @@ function ProjectDetails(props)
         </div>
 
         <div className="comment_content">
-          {ProjectDetails.comments.map((comment) => (
+          {ProjectDetails.comments && ProjectDetails.comments.map((comment) => (
             <div className="user_comment" key={comment._id}>
               <div className="comment_info">
                 <div className="comment_user">

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -37,6 +37,8 @@ export const initialState = {
     level: null,
     skills: null,
     github: null,
+    adder_id:null,
+    adder_fname:"",
     rating: 0,
     likes: 0,
     comments: [],


### PR DESCRIPTION
### Description

- Now when someone add a project his (adder's) id and firstname ( or Project Zone ) will be saved to db ,  and will be visible on project details. Onclick to his name people can see his profile 

Fixes #271

### Type of Change:

- New Feature

### How Has This Been Tested?
Its checked to show added by name or 'Project Zone' if don't have a added_id

### Checklist:
<!--**Delete irrelevant options.**-->

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes