### PR TITLE
Added search projects by skill and name feature

### DIFF
--- a/server/redis/client.js
+++ b/server/redis/client.js
@@ -1,13 +1,13 @@
-const redis = require("redis");
-const bluebird = require("bluebird");
+// const redis = require("redis");
+// const bluebird = require("bluebird");
 
-// Convert Redis client API to use promises, to make it usable with async/await syntax
-bluebird.promisifyAll(redis.RedisClient.prototype);
-bluebird.promisifyAll(redis.Multi.prototype);
+// // Convert Redis client API to use promises, to make it usable with async/await syntax
+// bluebird.promisifyAll(redis.RedisClient.prototype);
+// bluebird.promisifyAll(redis.Multi.prototype);
 
-const redisClient = redis.createClient(6380, process.env.REDISCACHEHOSTNAME, {
-  auth_pass: process.env.REDISCACHEKEY,
-  tls: { servername: process.env.REDISCACHEHOSTNAME },
-});
+// const redisClient = redis.createClient(6380, process.env.REDISCACHEHOSTNAME, {
+//   auth_pass: process.env.REDISCACHEKEY,
+//   tls: { servername: process.env.REDISCACHEHOSTNAME },
+// });
 
-module.exports = redisClient;
+// module.exports = redisClient;

--- a/server/routes/projectRoutes.js
+++ b/server/routes/projectRoutes.js
@@ -7,9 +7,9 @@ const { HomePageProjects, GetProjectByID } = require("./../controllers/public");
 // Routes
 /**
  * @swagger
- * /getprojects:
+ * /getprojectsbyskill:
  *  get:
- *    description: Get a list of projects on the basis of query
+ *    description: Get a list of projects by skill on the basis of query
  *    responses:
  *      '200':
  *        description: Response Successful
@@ -18,7 +18,7 @@ const { HomePageProjects, GetProjectByID } = require("./../controllers/public");
  *      '500':
  *        description: Internal server error
  */
-projectsRouter.get("/getprojects", async (req, res) =>
+projectsRouter.get("/getprojectsbyskill", async (req, res) =>
 {
   var query = req.query.q;
   query = query.toLowerCase();
@@ -41,6 +41,43 @@ projectsRouter.get("/getprojects", async (req, res) =>
     return res.staus(500).json({ message: "Internal server error" });
   }
 });
+
+/**
+ * @swagger
+ * /getprojectsbyname:
+ *  get:
+ *    description: Get a list of projects by name on the basis of query 
+ *    responses:
+ *      '200':
+ *        description: Response Successful
+ *      '404':
+ *        description: Not found.
+ *      '500':
+ *        description: Internal server error
+ */
+ projectsRouter.get("/getprojectsbyname", async (req, res) =>
+ {
+   var query = req.query.q;
+   query = query.toLowerCase();
+ 
+   try
+   {
+     const result = await Project.find({
+      name : {$regex : query, $options: "i"} 
+     });
+ 
+     if (result)
+     {
+       return res.status(200).json(result);
+     } else
+     {
+       return res.status(404).json({ message: "Projects Not found" });
+     }
+   } catch (err)
+   {
+     return res.staus(500).json({ message: "Internal server error" });
+   }
+ });
 
 // Routes
 /**

--- a/src/components/SearchBox/SearchBox.css
+++ b/src/components/SearchBox/SearchBox.css
@@ -11,16 +11,121 @@
     align-items: center;
     background-color: #FFF;
     border: 1px solid black;
-    padding: 0.1em 1.2em;
+    padding: 0 1.4em;
+    padding-right:0;
+    height: fit-content;
     border-radius: 5rem;
 }
 
-.input input {
+.search_form {
+    display:flex;
+    justify-content: space-between;
+    width: 65vw;
+    position: relative;
+}
+
+.search_form input {
     outline: none;
     border: none;
-    width: 65vw;
+    width:45vw;
     font-size: 1.2em;
     font-family: 'QuickSand';
-    padding: 0.6rem 1rem;
+    padding: 0.4rem 1.4rem;
     background: transparent;
 }
+
+.search_form .types_dropdown{
+    position:absolute;
+    left:74%;
+    display:flex;
+    flex-direction:column;
+    outline: none;
+    border: none;
+    min-width:15vw;
+    text-align: right;
+    margin-left:auto;
+    font-size: 1.2em;
+    font-family: 'QuickSand';
+    padding: 0.5rem;
+    background: transparent;
+}
+
+.currtype{
+    display:flex;
+    height:33px;
+    align-self: center;
+}
+.currtype p{
+    color: #5253ED;
+    font-weight:bold;
+    margin-left:10px;
+    cursor : pointer;
+    transform: translateY(-5px)
+}
+
+.typearrow{
+    transform: translateY(5px)
+}
+
+.types_overlay{
+    padding:0;
+    background-color:#fff;
+    color:#5253ED;
+    position: relative;
+    z-index:3;
+    width:10vw;
+    right:-10%;
+    top:0;
+    -webkit-box-shadow: 0 3px 5px -3px rgba(50, 50, 50, 0.75);
+    -moz-box-shadow: 0 3px 5px -3px rgba(50, 50, 50, 0.75);
+    box-shadow: 0 3px 5px -3px rgba(50, 50, 50, 0.75);
+}
+
+.qtype{
+    padding:0.2rem 0.4rem;
+    text-align: left;
+    width:100%;
+    cursor:pointer;
+}
+
+.typearrow{
+    cursor: pointer;
+}
+
+.qtype:hover{
+    background-color:#5253ED;
+    color:#fff;
+}
+
+@media screen and (max-width: 960px) {
+    .input{
+        padding:0 0.5rem;
+    }
+    .search_form {
+        width:80vw;
+    }
+    .search_form input {
+        width:45vw;
+        font-size:0.9em;
+    }
+    .search_form .types_dropdown{
+       left:55%;
+       min-width:33vw;
+       font-size:0.9em;
+       align-items:right;
+    }
+    .types_overlay{
+        width:100px;
+    }
+    .currtype{
+        height:25px;
+        width:33vw;
+    }
+    .currtype p{
+        transform: translateY(-8px);
+        margin:0 5px;
+    }
+}
+
+
+

--- a/src/components/SearchBox/SearchBox.js
+++ b/src/components/SearchBox/SearchBox.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import "./SearchBox.css";
 import SearchIcon from "@material-ui/icons/Search";
 import Autocomplete from "@material-ui/lab/Autocomplete";
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import { makeStyles } from "@material-ui/core/styles";
 import { useDataLayerValues } from "../../datalayer";
 
@@ -9,7 +10,6 @@ const useStyles = makeStyles((theme) => ({
   input: {
     textAlign: "center",
     fontWeight: "bold",
-    marginBottom: "1rem",
   },
   option: {
     color: "#000",
@@ -26,9 +26,11 @@ const useStyles = makeStyles((theme) => ({
 function SearchBox({ fetchProjects })
 {
   const classes = useStyles();
+  const [querytype, setQueryType] = useState("Skill");
+  const [typesSeen ,setTypesSeen ] = useState(false);
   const [{ query }, dispatch] = useDataLayerValues();
   const [querySearch, setQuerySearch] = useState(query);
-  const [placeholder, setPlaceholder] = useState("e.g. reactjs (press space to focus then type and select)");
+  const [placeholder, setPlaceholder] = useState("e.g. reactjs (press space to focus)");
   const searchOptions = [ 
     "reactjs",
     "javascript",
@@ -52,6 +54,15 @@ function SearchBox({ fetchProjects })
     "machine learning",
     "artificial intellegence"
   ] 
+
+  const handleTypesSeen = (event) => {
+    setTypesSeen(!typesSeen);
+  }
+
+  const handleSelect = (event) => {
+    setQueryType(event.target.innerText);
+    setTypesSeen(!typesSeen);
+  }
 
   const handleSpaceKeyPress = useCallback(event =>
   {
@@ -81,21 +92,21 @@ function SearchBox({ fetchProjects })
       type: "SET_QUERY",
       query: querySearch,
     });
-    fetchProjects(querySearch);
+    fetchProjects(querySearch, querytype);
   }
 
   return (
     <div className="searchBox">
       <div className="input">
         <SearchIcon onClick={fetchProjects} style={{ cursor: "pointer" }} />
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="search_form">
           <Autocomplete
             id="searchboxinput"
             noOptionsText={'try again and select option from dropdown'}
-            options={searchOptions}
+            options={querytype === 'Skill' ? searchOptions : []}
             value={querySearch}
             onChange={(event, value) => setQuerySearch(value)}
-            freeSolo={false}
+            freeSolo={querytype === 'Name'}
             classes={{ option: classes.option }}
             renderInput={(params) => (
               <div ref={params.InputProps.ref}>
@@ -103,11 +114,25 @@ function SearchBox({ fetchProjects })
                   type="text"
                   placeholder={placeholder}
                   className={classes.input}
+                  value={querySearch}
+                  onChange={(e) => setQuerySearch(e.target.value)}
                   {...params.inputProps}
                 />
               </div>
               )}
             />
+            <div className="types_dropdown">
+              <div className="currtype">
+                Search By <p onClick={handleTypesSeen}>{querytype}<ArrowDropDownIcon className="typearrow"/></p>
+              </div> 
+              {
+                typesSeen && 
+                <div className="types_overlay">
+                  <div className="qtype" value="Skill" onClick={handleSelect}>Skill</div>
+                  <div className="qtype" value="Name" onClick={handleSelect}>Name</div>
+                </div>
+              }
+            </div>
         </form>
       </div>
     </div>

--- a/src/components/ShowProjects/Showprojects.js
+++ b/src/components/ShowProjects/Showprojects.js
@@ -100,9 +100,10 @@ function Showprojects()
   // "VR"
   const [randomProject, setRandomProject] = useState("");
 
-  const fetchProjects = async (queryoption = "") =>
+  const fetchProjects = async (queryoption = "",querytype = "Skill") =>
   {
     setIsLoading(true);
+    const type = querytype.toLowerCase();
 
     try
     {
@@ -110,7 +111,7 @@ function Showprojects()
 
       if (queryoption !== "")
       {
-        const results = await server.get(`/getprojects?q=${ queryoption }`);
+        const results = await server.get(`/getprojectsby${type}?q=${ queryoption }`);
         setProjects(results.data);
         setFilteredProjects(results.data);
         setTotalPages(Math.ceil(results.data.length / itemsPerPage));
@@ -118,7 +119,7 @@ function Showprojects()
 
       } else if (query !== "")
       {
-        const results = await server.get(`/getprojects?q=${ query }`);
+        const results = await server.get(`/getprojectsby${type}?q=${ query }`);
         setProjects(results.data);
         setFilteredProjects(results.data);
         setTotalPages(Math.ceil(results.data.length / itemsPerPage));


### PR DESCRIPTION
### Description

- now user can search projects by skill or name by selecting a type on searchbar. 
- for search by skill , projects having query skill as one of the skills will be fetched .
- for search by name, projects which name includes query name will be fetched .

Fixes #277 

### Type of Change:

- New Feature

### How Has This Been Tested?
when user search by skills, he will have some options to search and select from dropdown , selecting which is fetching projects
when user search by name, he will be free to type words i.e. game, clone, e-commerce , and that word is being used to fetch projects


### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes